### PR TITLE
fix incorret tab index (key cmd+num) after tab is dragged

### DIFF
--- a/Welly/WLMainFrameController+TabControl.m
+++ b/Welly/WLMainFrameController+TabControl.m
@@ -37,6 +37,7 @@
     // the switch
     [self tabViewDidChangeNumberOfTabViewItems:_tabView];
 	[_tabBarControl setMainController:[self retain]];
+    [_tabView setTabBarControl:_tabBarControl];
 }
 
 #pragma mark -

--- a/Welly/WLTabView.m
+++ b/Welly/WLTabView.m
@@ -11,7 +11,7 @@
 #import "WLTerminal.h"
 #import "WLTerminalView.h"
 #import "WLMainFrameController.h"
-
+#import "WLTabBarControl.h"
 #import "WLTabViewItemController.h"
 
 #import "WLGlobalConfig.h"
@@ -25,11 +25,11 @@
 - (void)updatePortal;
 - (void)resetFrame;
 - (void)showPortal;
-
+@property WLTabBarControl* tabBarControl;
 @end
 
-
 @implementation WLTabView
+@synthesize tabBarControl = _tabBarControl;
 
 - (id)initWithFrame:(NSRect)frame {
     self = [super initWithFrame:frame];
@@ -291,7 +291,7 @@
 			   ([event modifierFlags] & NSShiftKeyMask) == 0 && 
 			   [[event characters] intValue] > 0 && 
 			   [[event characters] intValue] < 10) {
-		[self selectTabViewItemAtIndex:([[event characters] intValue]-1)];
+        [[self tabBarControl] selectTabViewItemAtIndex:([[event characters] intValue]-1)];
 		return YES;
 	} else if (([event modifierFlags] & NSCommandKeyMask) == 0 && 
 			   ([event modifierFlags] & NSAlternateKeyMask) == 0 && 


### PR DESCRIPTION
if user switch tab by drag, then the key switch (cmd+number) will be incorrect.